### PR TITLE
Process ResourceLists/ChangeLists only when they are new

### DIFF
--- a/docker/cfg/uri-list.txt
+++ b/docker/cfg/uri-list.txt
@@ -1,2 +1,3 @@
 http://zandbak11.dans.knaw.nl/ehri2/mdx/capabilitylist.xml
 http://zandbak11.dans.knaw.nl/ehri2/mdy/capabilitylist.xml
+http://zandbak11.dans.knaw.nl/ehri2/metadata/capabilitylist.xml

--- a/src/main/java/nl/knaw/dans/rs/aggregator/discover/RsExplorer.java
+++ b/src/main/java/nl/knaw/dans/rs/aggregator/discover/RsExplorer.java
@@ -91,6 +91,9 @@ public class RsExplorer extends AbstractUriExplorer {
   public Result<RsRoot> explore(URI uri, ResultIndex index) {
     Result<RsRoot> result = execute(uri, getConverter());
     index.add(result);
+    if (result.hasErrors()) {
+      return result;
+    }
     Capability capability = extractCapability(result);
 
     if (followParentLinks) {

--- a/src/main/java/nl/knaw/dans/rs/aggregator/sync/SitemapCollector.java
+++ b/src/main/java/nl/knaw/dans/rs/aggregator/sync/SitemapCollector.java
@@ -224,6 +224,9 @@ public class SitemapCollector implements RsConstants {
     for (Result<?> result : currentIndex.getResultMap().values()) {
       if (result.hasErrors()) {
         errorResults.add(result);
+        for (Throwable error : result.getErrors()){
+          logger.warn("Result has errors. URI: {}, msg: {}", pathFinder.getCapabilityListUri(), error.getMessage());
+        }
       } else {
         analyze(result);
       }
@@ -380,7 +383,8 @@ public class SitemapCollector implements RsConstants {
       return;
     }
     Optional<ZonedDateTime> maybeListCompletedAt = resourcelist.getMetadata().getCompleted();
-    if( ! maybeListCompletedAt.isPresent() || maybeListCompletedAt.get().isAfter(getAsOfDateTime()) ){
+    ZonedDateTime rlDate = maybeListCompletedAt.orElse(listAt);
+    if( rlDate.isAfter(getAsOfDateTime()) ){
       countResourceLists++;
 
       // walk item list
@@ -418,8 +422,8 @@ public class SitemapCollector implements RsConstants {
     }
 
     Optional<ZonedDateTime> maybeListUntil = changelist.getMetadata().getUntil();
-//    if (listFrom.isAfter(getAsOfDateTime())) {
-    if ( ! maybeListUntil.isPresent() || maybeListUntil.get().isAfter(getAsOfDateTime())) {
+    ZonedDateTime clDate = maybeListUntil.orElse(listFrom);
+    if ( clDate.isAfter(getAsOfDateTime())) {
       countChangeLists++;
 
       // walk item list

--- a/src/main/java/nl/knaw/dans/rs/aggregator/sync/SitemapCollector.java
+++ b/src/main/java/nl/knaw/dans/rs/aggregator/sync/SitemapCollector.java
@@ -195,7 +195,7 @@ public class SitemapCollector implements RsConstants {
     return ultimateChangeListFrom;
   }
 
-  public ZonedDateTime getUltmateListDate() {
+  public ZonedDateTime getUltimateListDate() {
     return ultimateChangeListFrom.isAfter(ultimateResourceListAt) ? ultimateChangeListFrom : ultimateResourceListAt;
   }
 
@@ -379,7 +379,6 @@ public class SitemapCollector implements RsConstants {
       logger.warn("Missing required md:at attribute on resourceList at {}", usResult);
       return;
     }
-
     if (listAt.isAfter(getAsOfDateTime())) {
       countResourceLists++;
 
@@ -395,7 +394,8 @@ public class SitemapCollector implements RsConstants {
         mergeItem(usResult, item);
       }
     } else {
-      logger.info("Skipping resourceList because {} <= {}: {}", listAt, getAsOfDateTime(), usResult);
+      logger.info("Skipping resourceList because {} <= {}", listAt, getAsOfDateTime());
+      logger.debug("Skipping resourceList because {} <= {}: {}", listAt, getAsOfDateTime(), usResult);
     }
   }
 
@@ -455,7 +455,8 @@ public class SitemapCollector implements RsConstants {
         mergeItem(usResult, item);
       }
     } else {
-      logger.info("Skipping changeList because {} <= {}: {}", listFrom, getAsOfDateTime(), usResult);
+      logger.info("Skipping changeList because {} <= {}", listFrom, getAsOfDateTime());
+      logger.debug("Skipping changeList because {} <= {}: {}", listFrom, getAsOfDateTime(), usResult);
     }
   }
 

--- a/src/main/java/nl/knaw/dans/rs/aggregator/sync/SyncJob.java
+++ b/src/main/java/nl/knaw/dans/rs/aggregator/sync/SyncJob.java
@@ -202,11 +202,7 @@ public class SyncJob implements Job {
         throw new RuntimeException("Could not load syncProps from " + prevSyncPropFile, e);
       }
     }
-    if(latestSyncRun != null) {
-      sitemapCollector.withAsOfDateTime(latestSyncRun);
-    }else{
-      sitemapCollector.withAsOfDateTime(null);
-    }
+    sitemapCollector.withAsOfDateTime(latestSyncRun);
     logger.info("only looking at item-events after {}", sitemapCollector.getAsOfDateTime());
   }
 


### PR DESCRIPTION
Goal is to have the statistics-log info reflect the actual changes in the Source. 
so running the aggregator twice should yield 0 changes if nothing happened in between.

Part of this functionality was already implemented, only the last-date was not set properly

When setting up the SyncJob, it tries to read the properties from the last run. the StartDate of the last run is used 

for ResourceLists to be considered, the `completed` attribute needs to be empty, or after the StartDate. All url-items in the ResourceList are then processed.

for ChangeLists to be considered, the `until` attribute needs to be empty, or after the StartDate. Only url-items with a `datetime` after StartDate are then processed. 

Deleting all files in the __SYNC_PROPS__ folder will trigger a complete reharvest
  